### PR TITLE
Update main.nf

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -578,7 +578,6 @@ process cutadapt {
 
     script:
     """
-    ln -s $reads ${name}.fastq.gz
     cutadapt -j $task.cpus -a ${params.adapter} -m 12 -o ${name}.trimmed.fastq.gz ${name}.fastq.gz > ${name}_cutadapt.log
     """
 }
@@ -712,10 +711,12 @@ if (params.deduplicate) {
         """
     }
 } else {
-    ch_dedup = ch_aligned
+    ch_aligned.into{
+        ch_dedup
+        ch_dedup_rseqc
+    }
     ch_dedup_mqc = Channel.empty()
     ch_dedup_qc = Channel.empty()
-    ch_dedup_rseqc = ch_aligned
 }
 
 /*


### PR DESCRIPTION
Without UMI deduplication the same channel `ch_aligned` is used twice and it causes errors during pipeline execution

Also command `ln $X $X` returns an error

<!--
# nf-core/clipseq pull request

Many thanks for contributing to nf-core/clipseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/clipseq/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/clipseq/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/clipseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
