### PR TITLE
updated reference paths and UMI param names in test_full.config

### DIFF
--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -17,14 +17,16 @@ params {
     config_profile_description = 'Full test dataset to check pipeline function'
 
     // Input data for full size test
-    input = 'https://raw.githubusercontent.com/nf-core/clipseq/refs/heads/feat-2-0/tests/test_new_samplesheet_FASTQ_full.csv'
+    input  = 'https://raw.githubusercontent.com/nf-core/clipseq/refs/heads/feat-2-0/tests/test_new_samplesheet_FASTQ_full.csv'
     source = "fastq"
 
     // Genome references
-    ncrna_fasta = "https://raw.githubusercontent.com/nf-core/test-datasets/clipseq/v_2_0/genome/homosapiens_smallRNA.fa.gz"
-    fasta = 'https://ftp.ensembl.org/pub/release-111/fasta/homo_sapiens/dna/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz'
-    gtf = 'https://ftp.ensembl.org/pub/release-111/gtf/homo_sapiens/Homo_sapiens.GRCh38.111.gtf.gz'
-    umitools_bc_pattern = 'NNNNNNNNN'
-    umitools_umi_separator = '_'
-    skip_umi_extract = false
+    ncrna_fasta  = "https://raw.githubusercontent.com/nf-core/test-datasets/clipseq/v_2_0/genome/homosapiens_smallRNA.fa.gz"
+    fasta        = 'https://ftp.ensembl.org/pub/release-111/fasta/homo_sapiens/dna/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz'
+    gtf          = 'https://ftp.ensembl.org/pub/release-111/gtf/homo_sapiens/Homo_sapiens.GRCh38.111.gtf.gz'
+
+    // UMI options
+    umitools_bc_pattern     = 'NNNNNNNNN'
+    umitools_umi_separator  = '_'
+    skip_umi_extract        = false
 }

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -21,9 +21,10 @@ params {
     source = "fastq"
 
     // Genome references
-    ncrna_fasta   = "https://raw.githubusercontent.com/nf-core/test-datasets/clipseq/v_2_0/genome/homosapiens_smallRNA.fa.gz"
-    fasta         = 's3://ngi-igenomes/test-data/clipseq/input_data/reference/GRCh38.primary_assembly.genome.fa.gz'
-    gtf           = 's3://ngi-igenomes/test-data/clipseq/input_data/reference/gencode.v37.primary_assembly.annotation.gtf.gz'
-    move_umi      = 'NNNNNNNNN'
-    umi_separator = '_'
+    ncrna_fasta = "https://raw.githubusercontent.com/nf-core/test-datasets/clipseq/v_2_0/genome/homosapiens_smallRNA.fa.gz"
+    fasta = 'https://ftp.ensembl.org/pub/release-111/fasta/homo_sapiens/dna/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz'
+    gtf = 'https://ftp.ensembl.org/pub/release-111/gtf/homo_sapiens/Homo_sapiens.GRCh38.111.gtf.gz'
+    umitools_bc_pattern = 'NNNNNNNNN'
+    umitools_umi_separator = '_'
+    skip_umi_extract = false
 }


### PR DESCRIPTION
Changes to test_full config so running the pipeline with `-profile test_full` runs beyond UMI deduplication:
- updated FASTA and GTF paths to those hosted on Ensembl instead of igenomes. These are downloaded at runtime (tested).
- renamed UMI related params to match those in `nextflow.config` and enabled UMI extraction (so now UMI collapse doesn't fail)
- despite these changes that help the test_full progress further, test_full still fails in later steps at processes related to consensus peak analyses

<!--
# nf-core/clipseq pull request

Many thanks for contributing to nf-core/clipseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/clipseq/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/clipseq/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/clipseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
